### PR TITLE
Fix test case that was comparing the same operands.

### DIFF
--- a/bellt/pkg/command_test.go
+++ b/bellt/pkg/command_test.go
@@ -107,7 +107,7 @@ func TestArgumentFilter(t *testing.T) {
 		return
 	}
 
-	if command.Arguments[0] != command.Arguments[0] {
+	if want.Arguments[0] != command.Arguments[0] {
 		t.Errorf("Arguments configuration error: want %s, got %s", want.Arguments[0], command.Arguments[0])
 		return
 	}


### PR DESCRIPTION
Hey there!
I was [scanning a bunch of Go code](https://semgrep.live/scan/94e705a7-6483-4beb-856d-ee0c1c4b9fe2) and found this issue.
It looks like this test case in `bellt/pkg/command_test.go` intended to compare `want` to `command` but was comparing `command` twice.
This PR fixes that.
Hope it's helpful!